### PR TITLE
Update call to build with current timestamp

### DIFF
--- a/stability/runPythonOnWindows.bat
+++ b/stability/runPythonOnWindows.bat
@@ -1,8 +1,9 @@
 py %WORKSPACE%\stability\stability\windows_native-stability-test.py --stabilization --iterations=10
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
-For /f "tokens=1-2 delims=: " %%a in ('time /t') do (set mytime=%%a-%%b)
+For /f "tokens=1-2 delims=: " %%a in ('time /t') do (set mytime=%%a:%%b)
+set timestamp=%mydate%T%mytime%Z
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\submission-metadata.py --name "%COMPUTERNAME% Stability Run %mydate%-%mytime%" --user-email "dotnet-bot@microsoft.com"
-py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\build.py git --type rolling --branch master --number %mydate%-%mytime%
+py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\build.py git --type rolling --branch master --number %mydate%-%mytime% --source-timestamp "%timestamp%"
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\machinedata.py
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\measurement.py csv "stability.csv" --metric "Elapsed Time" --unit "Seconds" --better desc
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\submission.py measurement.json ^


### PR DESCRIPTION
When we were generating the build.json file for the insertion of the
data into Benchview we were just using the last source timestamp of the
git repo.  This is causing all of the data to have the same timestamp
and it is not displaying properly on the website.  I have added the
current time as a timestamp and that should fix this issue.