### PR TITLE
Add new label to stability runs

### DIFF
--- a/stability.groovy
+++ b/stability.groovy
@@ -22,7 +22,7 @@ folder('stability_testing') {}
 // 1) Native testing of known binaries (a few parsec benchmarks) that are very stable.
 // 2) Managed testing of known binaries that are stable
 
-['windows'].each { osFamily ->
+['windows', 'windows_server_2016'].each { osFamily ->
     def nativeStabilityJob = job(Utilities.getFullJobName("${osFamily}_native_stability_test", false, stabilityTestingFolderName)) {
         // Add a parameter to specify which nodes to run the stability job across
         parameters {
@@ -38,7 +38,7 @@ folder('stability_testing') {}
 					}
 				}
         steps {
-            if (osFamily == 'windows') {
+            if (osFamily != 'linux') {
                 batchFile("C:\\Tools\\nuget.exe install Microsoft.BenchView.JSONFormat -Source http://benchviewtestfeed.azurewebsites.net/nuget -OutputDirectory \"%WORKSPACE%\" -Prerelease -ExcludeVersion")
                 batchFile('stability\\runPythonOnWindows.bat')
             }

--- a/stability/runPythonOnWindows.bat
+++ b/stability/runPythonOnWindows.bat
@@ -1,4 +1,4 @@
-START "CORECLR_PERF_RUN" /B /WAIT /HIGH /AFFINITY 0x2 py %WORKSPACE%\stability\stability\windows_native-stability-test.py --iterations=11
+py %WORKSPACE%\stability\stability\windows_native-stability-test.py --iterations=11
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=: " %%a in ('time /t') do (set mytime=%%a:%%b)
 set timestamp=%mydate%T%mytime%:00Z

--- a/stability/runPythonOnWindows.bat
+++ b/stability/runPythonOnWindows.bat
@@ -1,11 +1,11 @@
-py %WORKSPACE%\stability\stability\windows_native-stability-test.py --stabilization --iterations=10
+START "CORECLR_PERF_RUN" /B /WAIT /HIGH /AFFINITY 0x2 py %WORKSPACE%\stability\stability\windows_native-stability-test.py --iterations=11
 For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
 For /f "tokens=1-2 delims=: " %%a in ('time /t') do (set mytime=%%a:%%b)
 set timestamp=%mydate%T%mytime%:00Z
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\submission-metadata.py --name "%COMPUTERNAME% Stability Run %mydate%-%mytime%" --user-email "dotnet-bot@microsoft.com"
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\build.py git --type rolling --branch master --number %mydate%-%mytime% --source-timestamp "%timestamp%"
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\machinedata.py
-py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\measurement.py csv "stability.csv" --metric "Elapsed Time" --unit "Seconds" --better desc
+py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\measurement.py csv "stability.csv" --metric "Elapsed Time" --unit "Seconds" --better desc --drop-first-value
 py %WORKSPACE%\Microsoft.BenchView.JSONFormat\tools\submission.py measurement.json ^
                                                                --build build.json ^
                                                                --machine-data machinedata.json ^

--- a/stability/stability/windows_native-stability-test.py
+++ b/stability/stability/windows_native-stability-test.py
@@ -148,7 +148,7 @@ def runParsec():
     targetFile = os.path.join(targetDir, 'blackscholes.tar.gz')
     downloadAndUnpack(benchmarkLocation, targetFile)
     
-    return runAndProcess("%WORKSPACE%\\blackscholes_cpp_serial 1 in_10M.txt prices.txt", parsecProcessResults)
+    return runAndProcess("START \"STABILITY_PERF_RUN\" /B /WAIT /HIGH /AFFINITY 0x2 %WORKSPACE%\\blackscholes_cpp_serial 1 in_10M.txt prices.txt", parsecProcessResults)
     
 # List of benchmarks to run
 benchmarkRunners = {'Parsec': runParsec}


### PR DESCRIPTION
This change adds stability runs to the new Windows Server 2016 label as
well as increasing the number of iterations to 11 and dropping the
first.  We have also added the same stability prefix that we are using
for regular performance runs to try and remove as much noise as possible
from the benchmark.